### PR TITLE
Add optional headers on sendTokenRequest

### DIFF
--- a/src/issuance.ts
+++ b/src/issuance.ts
@@ -58,13 +58,14 @@ export async function sendTokenRequest<T extends TokenResponseProtocol>(
     issuerUrl: string,
     tokReq: TokenRequestProtocol,
     tokRes: { new (_: Uint8Array): T },
+    headers?: Headers,
 ): Promise<T> {
+    headers ??= new Headers();
+    headers.append('Content-Type', MediaType.PRIVATE_TOKEN_REQUEST);
+    headers.append('Accept', MediaType.PRIVATE_TOKEN_RESPONSE);
     const issuerResponse = await fetch(issuerUrl, {
         method: 'POST',
-        headers: [
-            ['Content-Type', MediaType.PRIVATE_TOKEN_REQUEST],
-            ['Accept', MediaType.PRIVATE_TOKEN_RESPONSE],
-        ],
+        headers,
         body: tokReq.serialize().buffer,
     });
 


### PR DESCRIPTION
Allow developers using the library to send custom headers alongside a token request.
This is useful for attester that would receive a token request from clients, and might need additional authentication, or message passing mechanism.