### PR TITLE
Update PrivateToken.parse to be synchronous

### DIFF
--- a/src/httpAuthScheme.ts
+++ b/src/httpAuthScheme.ts
@@ -133,7 +133,7 @@ export class PrivateToken {
         this.challengeSerialized = challenge.serialize();
     }
 
-    static async parse(data: string): Promise<PrivateToken> {
+    static parse(data: string): PrivateToken {
         // Consumes data:
         //   challenge="abc...", token-key="123..."
 
@@ -180,7 +180,7 @@ export class PrivateToken {
         return pt;
     }
 
-    static async parseMultiple(header: string): Promise<PrivateToken[]> {
+    static parseMultiple(header: string): PrivateToken[] {
         // Consumes data:
         //   PrivateToken challenge="abc...", token-key="123...",
         //   PrivateToken challenge="def...", token-key="234..."
@@ -193,14 +193,14 @@ export class PrivateToken {
                 continue;
             }
             const chl = challenge.slice('PrivateToken '.length);
-            const privToken = await PrivateToken.parse(chl);
+            const privToken = PrivateToken.parse(chl);
             listTokens.push(privToken);
         }
 
         return listTokens;
     }
 
-    async toString(quotedString = false): Promise<string> {
+    toString(quotedString = false): string {
         // WWW-Authenticate does not impose authentication parameters escape with a double quote
         // For more details, refer to RFC9110 Section 11.2 https://www.rfc-editor.org/rfc/rfc9110#section-11.2
         const quote = quotedString ? '"' : '';

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export * as httpAuthScheme from './httpAuthScheme.js';
 export * as issuance from './issuance.js';
 
 export async function header_to_token(header: string): Promise<string | null> {
-    const privateTokens = await PrivateToken.parseMultiple(header);
+    const privateTokens = PrivateToken.parseMultiple(header);
     if (privateTokens.length === 0) {
         return null;
     }

--- a/test/authScheme.test.ts
+++ b/test/authScheme.test.ts
@@ -40,8 +40,8 @@ test.each(tokenVectors)('AuthScheme-TokenVector-%#', async (v: TokenVectors) => 
 
 type HeaderVectors = (typeof headerVectors)[number];
 
-test.each(headerVectors)('AuthScheme-HeaderVector-%#', async (v: HeaderVectors) => {
-    const tokens = await PrivateToken.parseMultiple(v['WWW-Authenticate']);
+test.each(headerVectors)('AuthScheme-HeaderVector-%#', (v: HeaderVectors) => {
+    const tokens = PrivateToken.parseMultiple(v['WWW-Authenticate']);
 
     let i = 0;
     for (const t of tokens) {


### PR DESCRIPTION
Both PrivateToken.parse and PrivateToken.parseMultiple are not awaiting on any Promise. They don't need to be async.

This commit updates these function signatures to reflect this.