### PR TITLE
Update export to be at first level

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,15 +1,15 @@
 // Copyright (c) 2023 Cloudflare, Inc.
 // Licensed under the Apache-2.0 license found in the LICENSE file or at https://opensource.org/licenses/Apache-2.0
 
-import { TokenType as PubTokenType, fetchPublicVerifToken } from './pubVerifToken.js';
-import { PrivateToken } from './httpAuthScheme.js';
+import { TOKEN_TYPES } from './pubVerifToken.js';
+import { PrivateToken, Token } from './httpAuthScheme.js';
 import { base64url } from 'rfc4648';
 
 import { convertEncToRSASSAPSS, convertRSASSAPSSToEnc } from './util.js';
 export const util = { convertEncToRSASSAPSS, convertRSASSAPSSToEnc };
-export * as pubVerfiToken from './pubVerifToken.js';
-export * as httpAuthScheme from './httpAuthScheme.js';
-export * as issuance from './issuance.js';
+export * from './pubVerifToken.js';
+export * from './httpAuthScheme.js';
+export * from './issuance.js';
 
 export async function header_to_token(header: string): Promise<string | null> {
     const privateTokens = PrivateToken.parseMultiple(header);
@@ -21,8 +21,8 @@ export async function header_to_token(header: string): Promise<string | null> {
     const pt = privateTokens[0];
     const tokenType = pt.challenge.tokenType;
     switch (tokenType) {
-        case PubTokenType.value: {
-            const token = await fetchPublicVerifToken(pt);
+        case TOKEN_TYPES.BLIND_RSA.value: {
+            const token = await Token.fetch(pt);
             const encodedToken = base64url.stringify(token.serialize());
             return encodedToken;
         }

--- a/src/pubVerifToken.ts
+++ b/src/pubVerifToken.ts
@@ -3,22 +3,11 @@
 
 import { SUITES } from '@cloudflare/blindrsa-ts';
 
-import {
-    TokenTypeEntry,
-    PrivateToken,
-    TokenPayload,
-    Token,
-    TokenChallenge,
-} from './httpAuthScheme.js';
+import { TokenTypeEntry, PrivateToken, TokenPayload, Token } from './httpAuthScheme.js';
 import { convertRSASSAPSSToEnc, joinAll } from './util.js';
-import {
-    sendTokenRequest,
-    getIssuerUrl,
-    TokenResponseProtocol,
-    TokenRequestProtocol,
-} from './issuance.js';
+import { TokenResponseProtocol, TokenRequestProtocol, MediaType } from './issuance.js';
 
-export const TokenType: TokenTypeEntry = {
+const BLIND_RSA: TokenTypeEntry = {
     value: 0x0002,
     name: 'Blind RSA (2048)',
     Nk: 256,
@@ -28,17 +17,21 @@ export const TokenType: TokenTypeEntry = {
     privateMetadata: false,
 } as const;
 
+export const TOKEN_TYPES = {
+    BLIND_RSA,
+} as const;
+
 export class TokenRequest implements TokenRequestProtocol {
     tokenType: number;
     constructor(
         public tokenKeyId: number,
         public blindedMsg: Uint8Array,
     ) {
-        if (blindedMsg.length !== TokenType.Nk) {
+        if (blindedMsg.length !== BLIND_RSA.Nk) {
             throw new Error('invalid blinded message size');
         }
 
-        this.tokenType = TokenType.value;
+        this.tokenType = BLIND_RSA.value;
     }
 
     static deserialize(bytes: Uint8Array): TokenRequest {
@@ -48,14 +41,14 @@ export class TokenRequest implements TokenRequestProtocol {
         const type = input.getUint16(offset);
         offset += 2;
 
-        if (type !== TokenType.value) {
+        if (type !== BLIND_RSA.value) {
             throw new Error('mismatch of token type');
         }
 
         const tokenKeyId = input.getUint8(offset);
         offset += 1;
 
-        const len = TokenType.Nk;
+        const len = BLIND_RSA.Nk;
         const blindedMsg = new Uint8Array(input.buffer.slice(offset, offset + len));
         offset += len;
 
@@ -78,17 +71,50 @@ export class TokenRequest implements TokenRequestProtocol {
 
         return new Uint8Array(joinAll(output));
     }
+
+    // Send TokenRequest to Issuer (fetch w/POST).
+    async send<T extends TokenResponseProtocol>(
+        issuerUrl: string,
+        tokRes: { new (_: Uint8Array): T },
+        headers?: Headers,
+    ): Promise<T> {
+        headers ??= new Headers();
+        headers.append('Content-Type', MediaType.PRIVATE_TOKEN_REQUEST);
+        headers.append('Accept', MediaType.PRIVATE_TOKEN_RESPONSE);
+        const issuerResponse = await fetch(issuerUrl, {
+            method: 'POST',
+            headers,
+            body: this.serialize().buffer,
+        });
+
+        if (issuerResponse.status !== 200) {
+            const body = await issuerResponse.text();
+            throw new Error(
+                `tokenRequest failed with code:${issuerResponse.status} response:${body}`,
+            );
+        }
+
+        const contentType = issuerResponse.headers.get('Content-Type');
+
+        if (!contentType || contentType.toLowerCase() !== MediaType.PRIVATE_TOKEN_RESPONSE) {
+            throw new Error(`tokenRequest: missing ${MediaType.PRIVATE_TOKEN_RESPONSE} header`);
+        }
+
+        //  Receive a TokenResponse,
+        const resp = new Uint8Array(await issuerResponse.arrayBuffer());
+        return new tokRes(resp);
+    }
 }
 
 export class TokenResponse implements TokenResponseProtocol {
     constructor(public blindSig: Uint8Array) {
-        if (blindSig.length !== TokenType.Nk) {
+        if (blindSig.length !== BLIND_RSA.Nk) {
             throw new Error('invalid blind signature size');
         }
     }
 
     static deserialize(bytes: Uint8Array): TokenResponse {
-        return new TokenResponse(bytes.slice(0, TokenType.Nk));
+        return new TokenResponse(bytes.slice(0, BLIND_RSA.Nk));
     }
 
     serialize(): Uint8Array {
@@ -97,7 +123,7 @@ export class TokenResponse implements TokenResponseProtocol {
 }
 
 export class Issuer {
-    static readonly TYPE = TokenType;
+    static readonly TYPE = BLIND_RSA;
 
     constructor(
         public name: string,
@@ -112,7 +138,7 @@ export class Issuer {
 }
 
 export class Client {
-    static readonly TYPE = TokenType;
+    static readonly TYPE = BLIND_RSA;
     private finData?: {
         publicKeyIssuer: CryptoKey;
         tokenInput: Uint8Array;
@@ -166,46 +192,4 @@ export class Client {
 
         return token;
     }
-}
-
-export async function createPrivateToken(
-    issuer: {
-        name: string;
-        publicKey: CryptoKey;
-    },
-    redemptionContext?: Uint8Array,
-    originInfo?: string[],
-    maxAge?: number,
-): Promise<PrivateToken> {
-    if (!redemptionContext) {
-        redemptionContext = new Uint8Array(0);
-    }
-
-    const tokenChallenge = new TokenChallenge(
-        TokenType.value,
-        issuer.name,
-        redemptionContext,
-        originInfo,
-    );
-    const publicKeySpki = new Uint8Array(await crypto.subtle.exportKey('spki', issuer.publicKey));
-
-    return new PrivateToken(tokenChallenge, publicKeySpki, maxAge);
-}
-
-export function verifyToken(publicKey: CryptoKey, token: Token): Promise<boolean> {
-    return crypto.subtle.verify(
-        { name: 'RSA-PSS', saltLength: 48 },
-        publicKey,
-        token.authenticator,
-        token.payload.serialize(),
-    );
-}
-
-export async function fetchPublicVerifToken(pt: PrivateToken): Promise<Token> {
-    const issuerUrl = await getIssuerUrl(pt.challenge.issuerName);
-    const client = new Client();
-    const tokReq = await client.createTokenRequest(pt);
-    const tokRes = await sendTokenRequest(issuerUrl, tokReq, TokenResponse);
-    const token = await client.finalize(tokRes);
-    return token;
 }

--- a/test/authScheme.test.ts
+++ b/test/authScheme.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2023 Cloudflare, Inc.
 // Licensed under the Apache-2.0 license found in the LICENSE file or at https://opensource.org/licenses/Apache-2.0
 
-import { TokenType as PubTokenType } from '../src/pubVerifToken.js';
+import { TOKEN_TYPES } from '../src/pubVerifToken.js';
 import { TokenChallenge, TokenPayload, PrivateToken } from '../src/httpAuthScheme.js';
 import { hexToString, hexToUint8, testSerialize, uint8ToHex } from './util.js';
 
@@ -17,7 +17,7 @@ type TokenVectors = (typeof tokenVectors)[number];
 
 test.each(tokenVectors)('AuthScheme-TokenVector-%#', async (v: TokenVectors) => {
     const tokenType = parseInt(v.token_type);
-    if (tokenType !== PubTokenType.value) {
+    if (tokenType !== TOKEN_TYPES.BLIND_RSA.value) {
         return;
     }
 
@@ -32,7 +32,7 @@ test.each(tokenVectors)('AuthScheme-TokenVector-%#', async (v: TokenVectors) => 
     testSerialize(TokenChallenge, challenge);
 
     const context = new Uint8Array(await crypto.subtle.digest('SHA-256', challengeSerialized));
-    const payload = new TokenPayload(PubTokenType, nonce, context, keyId);
+    const payload = new TokenPayload(TOKEN_TYPES.BLIND_RSA, nonce, context, keyId);
     const payloadEnc = payload.serialize();
 
     expect(uint8ToHex(payloadEnc)).toBe(v.token_authenticator_input);

--- a/test/pubVerifToken.test.ts
+++ b/test/pubVerifToken.test.ts
@@ -4,14 +4,7 @@
 import { jest } from '@jest/globals';
 import { base64 } from 'rfc4648';
 
-import {
-    Client,
-    Issuer,
-    TokenRequest,
-    TokenResponse,
-    TokenType,
-    verifyToken,
-} from '../src/pubVerifToken.js';
+import { Client, Issuer, TokenRequest, TokenResponse, TOKEN_TYPES } from '../src/pubVerifToken.js';
 import { convertRSASSAPSSToEnc } from '../src/util.js';
 import { TokenChallenge, PrivateToken, Token } from '../src/httpAuthScheme.js';
 import { hexToUint8, testSerialize, testSerializeType, uint8ToHex } from './util.js';
@@ -84,10 +77,10 @@ test.each(vectors)('PublicVerifiable-Vector-%#', async (v: Vectors) => {
     expect(uint8ToHex(tokResSer)).toBe(v.token_response);
 
     const token = await client.finalize(tokRes);
-    testSerializeType(TokenType, Token, token);
+    testSerializeType(TOKEN_TYPES.BLIND_RSA, Token, token);
 
     const tokenSer = token.serialize();
     expect(uint8ToHex(tokenSer)).toBe(v.token);
 
-    expect(await verifyToken(publicKey, token)).toBe(true);
+    expect(await token.verify(publicKey)).toBe(true);
 });


### PR DESCRIPTION
Emports were grouped based on internal file representation. This makes them inconvenient to import. For instance, to import `PrivateToken`, one would need to
```typescript
import { httpAuthScheme } from "@cloudflare/privacypass-ts";

httpAuthScheme.PrivateToken
```
This also makes interaction between methods hard to follow. To create such a token, you need to
```typescript
import { issuance } from "@cloudflare/privacypass-ts";

issuance.createPrivateToken(...)
```

This commit moves methods closer to their respective types, and exports types at the first level.
One can now
```typescript
import { PrivateToken } from "@cloudflare/privacypass-ts";

PrivateToken.fromInfos(...)
```
This commit also renames `TokenType` to `TOKENS_TYPES.BLIND_RSA`.