### PR TITLE
Fix equal sign at the end of token in WWW-Authenticate headers

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export * from './httpAuthScheme.js';
 export * from './issuance.js';
 
 export async function header_to_token(header: string): Promise<string | null> {
-    const privateTokens = PrivateToken.parseMultiple(header);
+    const privateTokens = PrivateToken.parse(header);
     if (privateTokens.length === 0) {
         return null;
     }

--- a/test/authScheme.test.ts
+++ b/test/authScheme.test.ts
@@ -41,7 +41,7 @@ test.each(tokenVectors)('AuthScheme-TokenVector-%#', async (v: TokenVectors) => 
 type HeaderVectors = (typeof headerVectors)[number];
 
 test.each(headerVectors)('AuthScheme-HeaderVector-%#', (v: HeaderVectors) => {
-    const tokens = PrivateToken.parseMultiple(v['WWW-Authenticate']);
+    const tokens = PrivateToken.parse(v['WWW-Authenticate']);
 
     let i = 0;
     for (const t of tokens) {

--- a/test/jest.setup-file.ts
+++ b/test/jest.setup-file.ts
@@ -1,7 +1,6 @@
 // Copyright (c) 2023 Cloudflare, Inc.
 // Licensed under the Apache-2.0 license found in the LICENSE file or at https://opensource.org/licenses/Apache-2.0
 
-
 // Mocking crypto with NodeJS WebCrypto module only for tests.
 import { webcrypto } from 'node:crypto';
 

--- a/test/pubVerifToken.test.ts
+++ b/test/pubVerifToken.test.ts
@@ -85,7 +85,7 @@ test.each(vectors)('PublicVerifiable-Vector-%#', async (v: Vectors) => {
     expect(await token.verify(publicKey)).toBe(true);
 
     const header = token.toString();
-    const parsedTokens = Token.parseMultiple(TOKEN_TYPES.BLIND_RSA, header);
+    const parsedTokens = Token.parse(TOKEN_TYPES.BLIND_RSA, header);
     const parsedToken = parsedTokens[0];
     expect(parsedTokens).toHaveLength(1);
     expect(parsedToken.payload.challengeDigest).toEqual(token.payload.challengeDigest);


### PR DESCRIPTION
Certain tokens observed in the wild have equals in them without being escaped. This prevents the library from parsing them. This commit fixes this behavior.