### PR TITLE
Add Token.parse and Token.parseMultiple to parse response token

### DIFF
--- a/src/rfc9110.ts
+++ b/src/rfc9110.ts
@@ -46,3 +46,31 @@ export function parseWWWAuthenticate(header: string): string[] {
 
     return matches;
 }
+
+function authParamToString(
+    param: string,
+    value: string | number | null,
+    quotedString: boolean,
+): string {
+    // WWW-Authenticate does not impose authentication parameters escape with a double quote
+    // For more details, refer to RFC9110 Section 11.2 https://www.rfc-editor.org/rfc/rfc9110#section-11.2
+    const quote = quotedString ? '"' : '';
+    if (value === null) {
+        return param;
+    }
+    return `${param}=${quote}${value}${quote}`;
+}
+
+export function toStringWWWAuthenticate(
+    authScheme: string,
+    authParams?: Record<string, string | number | null>,
+    quotedString = false,
+): string {
+    if (authParams === undefined) {
+        return authScheme;
+    }
+    const params = Object.entries(authParams)
+        .map(([param, value]) => authParamToString(param, value, quotedString))
+        .join(',');
+    return `${authScheme} ${params}`;
+}

--- a/test/pubVerifToken.test.ts
+++ b/test/pubVerifToken.test.ts
@@ -83,4 +83,14 @@ test.each(vectors)('PublicVerifiable-Vector-%#', async (v: Vectors) => {
     expect(uint8ToHex(tokenSer)).toBe(v.token);
 
     expect(await token.verify(publicKey)).toBe(true);
+
+    const header = token.toString();
+    const parsedTokens = Token.parseMultiple(TOKEN_TYPES.BLIND_RSA, header);
+    const parsedToken = parsedTokens[0];
+    expect(parsedTokens).toHaveLength(1);
+    expect(parsedToken.payload.challengeDigest).toEqual(token.payload.challengeDigest);
+    expect(parsedToken.payload.nonce).toEqual(token.payload.nonce);
+    expect(parsedToken.payload.tokenKeyId).toEqual(token.payload.tokenKeyId);
+    expect(parsedToken.payload.tokenType).toBe(token.payload.tokenType);
+    expect(parsedToken.authenticator).toEqual(token.authenticator);
 });


### PR DESCRIPTION
Challenge headers can be parsed via `PrivateToken.parse`. Response tokens should have the same functionality, as they would need to be parsed by attester/issuer, and serialised by origins and clients.

This commit adds this features, along with associated test over provided test vectors.