### PR TITLE
Add RAW-RSA support for Issuer blind signing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "0.4.0",
             "license": "Apache-2.0",
             "dependencies": {
-                "@cloudflare/blindrsa-ts": "0.1.2",
+                "@cloudflare/blindrsa-ts": "0.3.2",
                 "@cloudflare/voprf-ts": "0.21.2",
                 "asn1-parser": "1.1.8",
                 "asn1js": "3.0.5",
@@ -708,9 +708,9 @@
             "dev": true
         },
         "node_modules/@cloudflare/blindrsa-ts": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/@cloudflare/blindrsa-ts/-/blindrsa-ts-0.1.2.tgz",
-            "integrity": "sha512-+w1TO2+ekG7Iga2yLEvyf+XsqUhB0ats77hIkpHJTFM/6YEUfCiAIuOFRuKENTp9UrSMmaXB4XmUmonHfWlUKg==",
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/@cloudflare/blindrsa-ts/-/blindrsa-ts-0.3.2.tgz",
+            "integrity": "sha512-JWV+LH2ZB1RSZsinesVFK5rrStPevw3/lMmNdhbKlQsTXQXqCXUFxwuYlFwyDxVzQyl/rdB/vUIgxc7PXit/TQ==",
             "dependencies": {
                 "sjcl": "1.0.8"
             },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "clean": "rimraf lib coverage dist"
     },
     "dependencies": {
-        "@cloudflare/blindrsa-ts": "0.1.2",
+        "@cloudflare/blindrsa-ts": "0.3.2",
         "@cloudflare/voprf-ts": "0.21.2",
         "asn1-parser": "1.1.8",
         "asn1js": "3.0.5",

--- a/test/jest.setup-file.ts
+++ b/test/jest.setup-file.ts
@@ -2,8 +2,42 @@
 // Licensed under the Apache-2.0 license found in the LICENSE file or at https://opensource.org/licenses/Apache-2.0
 
 // Mocking crypto with NodeJS WebCrypto module only for tests.
+import { RSABSSA } from '@cloudflare/blindrsa-ts';
 import { webcrypto } from 'node:crypto';
+
+const parentSign = webcrypto.subtle.sign;
+
+// RSA-RAW is not supported by WebCrypto, so we need to mock it.
+// Taken from cloudflare/blindrsa-ts https://github.com/cloudflare/blindrsa-ts/blob/b7a4c669620fba62ce736fe84445635e222d0d11/test/jest.setup-file.ts#L8-L32
+async function mockSign(
+    algorithm: AlgorithmIdentifier | RsaPssParams | EcdsaParams,
+    key: CryptoKey,
+    data: Uint8Array,
+): Promise<ArrayBuffer> {
+    if (
+        algorithm === 'RSA-RAW' ||
+        (typeof algorithm !== 'string' && algorithm?.name === 'RSA-RAW')
+    ) {
+        const algorithmName = key.algorithm.name;
+        if (algorithmName !== 'RSA-RAW') {
+            throw new Error(`Invalid key algorithm: ${algorithmName}`);
+        }
+        key.algorithm.name = 'RSA-PSS';
+        try {
+            return RSABSSA.SHA384.PSSZero.Deterministic().blindSign(key, data);
+        } finally {
+            key.algorithm.name = algorithmName;
+        }
+    }
+
+    // webcrypto calls crypto, which is mocked. We need to restore the original implementation.
+    crypto.subtle.sign = parentSign;
+    const res = webcrypto.subtle.sign(algorithm, key, data);
+    crypto.subtle.sign = mockSign;
+    return res;
+}
 
 if (typeof crypto === 'undefined') {
     Object.assign(global, { crypto: webcrypto });
 }
+crypto.subtle.sign = mockSign;


### PR DESCRIPTION
Update @cloudflare/blindrsa-ts, as well as the Issuer interface to allow platform accelaration if available.
Tests are also updated with a mock implementation relying on cloudflare/blindrsa-ts