### PR TITLE
Release 0.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@cloudflare/privacypass-ts",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@cloudflare/privacypass-ts",
-            "version": "0.4.0",
+            "version": "0.5.0",
             "license": "Apache-2.0",
             "dependencies": {
                 "@cloudflare/blindrsa-ts": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@cloudflare/privacypass-ts",
-    "version": "0.4.0",
+    "version": "0.5.0",
     "description": "privacypass-ts: A TypeScript Library for the Privacy Pass Issuance Protocol",
     "author": "Armando Faz <armfazh@cloudflare.com>",
     "contributors": [


### PR DESCRIPTION
# Changelog

c66fc41 Add RAW-RSA support for Issuer blind signing
755dbc7 Rename Client2 to Client, and others classes.
2ecf4ce Adding two modes for blindRSA.
bf518c7 Updating test vectors with latest draft v16.
b8edd21 Adding test vectors for Private verifiable tokens.
a265c57 Adding support for PrivateVerifiable (VOPRF) tokens.
140ceef Bump @babel/traverse from 7.22.8 to 7.23.2
3864003 Address comments from review.
f6f6b7b Move auth scheme and its dependencies to a module.
3241fe3 Refactor to define core privacy pass protocol.