### PR TITLE
Add package level export for Public and Private Verif classes

### DIFF
--- a/examples/priv_verif.example.ts
+++ b/examples/priv_verif.example.ts
@@ -1,8 +1,8 @@
 // Copyright (c) 2023 Cloudflare, Inc.
 // Licensed under the Apache-2.0 license found in the LICENSE file or at https://opensource.org/licenses/Apache-2.0
 
-import { TOKEN_TYPES, TokenChallenge } from '../src/index.js';
-import { Client, Issuer, keyGen } from '../src/priv_verif_token.js';
+import { TOKEN_TYPES, TokenChallenge, privateVerif } from '../src/index.js';
+const { Client, Issuer, keyGen } = privateVerif;
 
 export async function privateVerifiableTokens(): Promise<void> {
     // Protocol Setup

--- a/examples/pub_verif.example.ts
+++ b/examples/pub_verif.example.ts
@@ -1,15 +1,9 @@
 // Copyright (c) 2023 Cloudflare, Inc.
 // Licensed under the Apache-2.0 license found in the LICENSE file or at https://opensource.org/licenses/Apache-2.0
 
-import { TOKEN_TYPES, TokenChallenge } from '../src/index.js';
-import {
-    BlindRSAMode,
-    Client,
-    Issuer,
-    getPublicKeyBytes,
-    keyGen,
-    verifyToken,
-} from '../src/pub_verif_token.js';
+import { TOKEN_TYPES, TokenChallenge, publicVerif } from '../src/index.js';
+type BlindRSAMode = publicVerif.BlindRSAMode;
+const { BlindRSAMode, Client, Issuer, getPublicKeyBytes, keyGen, verifyToken } = publicVerif;
 
 async function rsaVariant(mode: BlindRSAMode): Promise<void> {
     // Protocol Setup

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,8 @@ import { convertEncToRSASSAPSS, convertRSASSAPSSToEnc } from './util.js';
 export const util = { convertEncToRSASSAPSS, convertRSASSAPSSToEnc };
 export * from './auth_scheme/private_token.js';
 export * from './issuance.js';
+export * as privateVerif from './priv_verif_token.js';
+export * as publicVerif from './pub_verif_token.js';
 
 // Privacy Pass Token Type Registry
 // Supported:

--- a/test/priv_verif_token.test.ts
+++ b/test/priv_verif_token.test.ts
@@ -4,8 +4,14 @@
 import { jest } from '@jest/globals';
 import { VOPRFClient } from '@cloudflare/voprf-ts';
 
-import { Client, Issuer, TokenRequest, TokenResponse, VOPRF } from '../src/priv_verif_token.js';
-import { TokenChallenge, TOKEN_TYPES, Token, AuthorizationHeader } from '../src/index.js';
+import {
+    TokenChallenge,
+    TOKEN_TYPES,
+    Token,
+    AuthorizationHeader,
+    privateVerif,
+} from '../src/index.js';
+const { Client, Issuer, TokenRequest, TokenResponse, VOPRF } = privateVerif;
 
 import { hexToUint8, testSerialize, testSerializeType, uint8ToHex } from './util.js';
 

--- a/test/pub_verif_token.test.ts
+++ b/test/pub_verif_token.test.ts
@@ -5,14 +5,14 @@ import { jest } from '@jest/globals';
 import { base64 } from 'rfc4648';
 
 import {
-    Client,
-    Issuer,
-    TokenRequest,
-    TokenResponse,
-    verifyToken,
-    BlindRSAMode,
-} from '../src/pub_verif_token.js';
-import { util, TokenChallenge, TOKEN_TYPES, Token, AuthorizationHeader } from '../src/index.js';
+    util,
+    TokenChallenge,
+    TOKEN_TYPES,
+    Token,
+    AuthorizationHeader,
+    publicVerif,
+} from '../src/index.js';
+const { Client, Issuer, TokenRequest, TokenResponse, verifyToken, BlindRSAMode } = publicVerif;
 
 import { hexToUint8, testSerialize, testSerializeType, uint8ToHex } from './util.js';
 


### PR DESCRIPTION
Instead of importing from package/lib/pub_verif_token.ts (and priv resp), users should be able to import all classes at the package level. This commit exposes `publicVerif` and `privateVerif`, allowing users to import all classes.
Tests and examples have been updated to not rely on the internal package structure.