### PR TITLE
Add utilitary function `tokenRequestToTokenTypeEntry`

### DIFF
--- a/test/priv_verif_token.test.ts
+++ b/test/priv_verif_token.test.ts
@@ -10,6 +10,7 @@ import {
     Token,
     AuthorizationHeader,
     privateVerif,
+    tokenRequestToTokenTypeEntry,
 } from '../src/index.js';
 const { Client, Issuer, TokenRequest, TokenResponse, VOPRF } = privateVerif;
 
@@ -40,6 +41,7 @@ test.each(vectors)('PrivateVerifiable-Vector-%#', async (v: Vectors) => {
 
     const tokReqSer = tokReq.serialize();
     expect(uint8ToHex(tokReqSer)).toBe(v.token_request);
+    expect(tokenRequestToTokenTypeEntry(tokReqSer)).toBe(TOKEN_TYPES.VOPRF);
 
     const issuer = new Issuer('issuer.example.com', privateKey, publicKey);
     const tokRes = await issuer.issue(tokReq);

--- a/test/pub_verif_token.test.ts
+++ b/test/pub_verif_token.test.ts
@@ -11,6 +11,7 @@ import {
     Token,
     AuthorizationHeader,
     publicVerif,
+    tokenRequestToTokenTypeEntry,
 } from '../src/index.js';
 const { Client, Issuer, TokenRequest, TokenResponse, verifyToken, BlindRSAMode } = publicVerif;
 
@@ -78,6 +79,8 @@ describe.each(vectors)('PublicVerifiable-Vector-%#', (v: Vectors) => {
 
         const tokReqSer = tokReq.serialize();
         expect(uint8ToHex(tokReqSer)).toBe(v.token_request);
+        expect(tokenRequestToTokenTypeEntry(tokReqSer)).toBe(TOKEN_TYPES.BLIND_RSA);
+
         const issuer = new Issuer(mode, 'issuer.example.com', privateKey, publicKey, ...params);
         const tokRes = await issuer.issue(tokReq);
         testSerialize(TokenResponse, tokRes);


### PR DESCRIPTION
This allows an Issuer that would like to support multiple token types to distinguish multiple token requests.