### PR TITLE
Add Publically-Verifiable tokens limitations in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,13 @@
  - Public-Verifiable tokens with Metadata (Partially-Blind-RSA)
  - Private-Verifiable tokens (VOPRF)
 
+**Usage:**
+
+We provide examples in the [examples folder](examples).
+
+### Limitations
+
+- Public-Verifiable tokens with Metadata verification is not supported in browser environments. This is due to @cloudflare/blindrsa-ts [not supporting them](https://github.com/cloudflare/blindrsa-ts?tab=readme-ov-file#platform-specific-configuration).
 
 ### Development
 


### PR DESCRIPTION
These token verifications are not supported in browsers. Surface this limitation in the README.