### PR TITLE
Pass parameters to blindrsa

### DIFF
--- a/src/pub_verif_token.ts
+++ b/src/pub_verif_token.ts
@@ -226,9 +226,9 @@ abstract class PubliclyVerifiableIssuer {
     ) {
         this.suite = (extensions?: Extensions) => {
             if (extensions === undefined) {
-                return BLIND_RSA.suite[this.mode]();
+                return BLIND_RSA.suite[this.mode](this.params);
             } else {
-                const suite = PARTIALLY_BLIND_RSA.suite[this.mode]();
+                const suite = PARTIALLY_BLIND_RSA.suite[this.mode](this.params);
                 const serializedExtensions = extensions.serialize();
                 return {
                     blindSign: (privateKey: CryptoKey, blindMsg: Uint8Array) =>


### PR DESCRIPTION
This allows publicaly verifiable tokens to take advantage of platform optimisation such as RSA-RAW.
It was not passed, and was a regression.

This commit also updates the test to ensure the test environments support RSA-RAW.