### PR TITLE
Fix arbitrary batched tokens when request has length zero

### DIFF
--- a/src/arbitrary_batched_token.ts
+++ b/src/arbitrary_batched_token.ts
@@ -296,10 +296,6 @@ export class Issuer {
 
 export class Client {
     createTokenRequest(tokenRequests: TokenRequest[]): BatchedTokenRequest {
-        if (tokenRequests.length === 0) {
-            throw new Error('no token request');
-        }
-
         return new BatchedTokenRequest(tokenRequests);
     }
 

--- a/test/arbitrary_batched_token.test.ts
+++ b/test/arbitrary_batched_token.test.ts
@@ -150,3 +150,10 @@ describe.each(vectors)('ArbitraryBatched-Vector-%#', (v: Vectors) => {
         }
     });
 });
+
+describe('arbitrary batched unit tests', () => {
+    test('client should support initialisation with zero TokenRequest', () => {
+        const newClient = () => new BatchedTokenRequest([]);
+        expect(newClient).not.toThrow();
+    });
+});


### PR DESCRIPTION
Length zero is valid. The implementation of arbitrary batched token client should support that.