### PR TITLE
Fix arbitrary batched token example

### DIFF
--- a/examples/arbitrary_batched.example.ts
+++ b/examples/arbitrary_batched.example.ts
@@ -25,6 +25,7 @@ async function setupPublicVerif(mode: BlindRSAMode) {
 
     return { issuer, client, origin, pkIssuer };
 }
+
 async function setup() {
     const s1 = await setupPublicVerif(publicVerif.BlindRSAMode.PSS);
     const s2 = await setupPublicVerif(publicVerif.BlindRSAMode.PSSZero);

--- a/src/pub_verif_token.ts
+++ b/src/pub_verif_token.ts
@@ -97,7 +97,7 @@ function getCryptoKey(publicKey: Uint8Array): Promise<CryptoKey> {
 }
 
 export async function getPublicKeyBytes(publicKey: CryptoKey): Promise<Uint8Array> {
-    return new Uint8Array(await crypto.subtle.exportKey('spki', publicKey));
+    return convertEncToRSASSAPSS(new Uint8Array(await crypto.subtle.exportKey('spki', publicKey)));
 }
 
 async function getTokenKeyID(publicKey: Uint8Array): Promise<Uint8Array> {
@@ -245,7 +245,7 @@ abstract class PubliclyVerifiableIssuer {
     }
 
     async tokenKeyID(): Promise<Uint8Array> {
-        return getTokenKeyID(convertEncToRSASSAPSS(await getPublicKeyBytes(this.publicKey)));
+        return getTokenKeyID(await getPublicKeyBytes(this.publicKey));
     }
 
     verify(token: Token): Promise<boolean> {


### PR DESCRIPTION
Getting public key bytes was incorrect based on what the examples needed.

This commit update the code, and makes the example pass.

Closes #41