### PR TITLE
Fix typo in error message

### DIFF
--- a/src/priv_verif_token.ts
+++ b/src/priv_verif_token.ts
@@ -85,7 +85,7 @@ export class TokenRequest {
         public readonly blindedMsg: Uint8Array,
     ) {
         if (blindedMsg.length !== VOPRF.Ne) {
-            throw new Error('blinded message has invalide size');
+            throw new Error('blinded message has invalid size');
         }
 
         this.tokenType = VOPRF.value;


### PR DESCRIPTION
An additional 'e' slipped into the error message for blinded messages of the wrong size.