### PR TITLE
header_to_token: base64 only once

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -78,10 +78,8 @@ export async function header_to_token(header: string): Promise<string | null> {
             return null;
     }
 
-    const te = new TextEncoder();
     const authHeader = await fetchToken(client, pt);
-    const encodedToken = base64url.stringify(te.encode(authHeader.toString()));
-    return encodedToken;
+    return authHeader.toString();
 }
 
 export function tokenEntryToSerializedLength(tokenType: TokenTypeEntry): number {


### PR DESCRIPTION
[`header_to_token()`](https://github.com/cloudflare/privacypass-ts/blob/bcfde82357cde782db792602d02a19f545ca44f1/src/index.ts#L57) is a very nice high-level API for turning a `WWW-Authenticate` header (a Token Request) into an `Authorization` header (a Token).

Unfortunately, currently it's broken:  It encodes the header that `fetchToken()` returns ready to use (especially already encoded as base64) another time as base64. That is one time too many.