### PR TITLE
Fix byte offset bugs when working with Uint8Array subarrays

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,13 +85,15 @@ export async function header_to_token(header: string): Promise<string | null> {
 }
 
 export function tokenEntryToSerializedLength(tokenType: TokenTypeEntry): number {
+    // TokenRequest structure: 2-byte token_type + 1-byte truncated_token_key_id + blinded_msg
+    const headerLen = 3; // token_type (2) + truncated_token_key_id (1)
     switch (tokenType.value) {
         case TOKEN_TYPES.VOPRF.value:
-            return VOPRF.Ne + 2 * VOPRF.Nk;
+            return headerLen + VOPRF.Ne;
         case TOKEN_TYPES.BLIND_RSA.value:
-            return BLIND_RSA.Nk;
+            return headerLen + BLIND_RSA.Nk;
         case TOKEN_TYPES.PARTIALLY_BLIND_RSA.value:
-            return PARTIALLY_BLIND_RSA.Nk;
+            return headerLen + PARTIALLY_BLIND_RSA.Nk;
         default:
             throw new Error(`unrecognized or non-supported token type: ${tokenType.value}`);
     }
@@ -99,7 +101,7 @@ export function tokenEntryToSerializedLength(tokenType: TokenTypeEntry): number 
 
 export function tokenRequestToTokenTypeEntry(bytes: Uint8Array): TokenTypeEntry {
     // All token requests have a 2-byte value at the beginning of the token describing TokenTypeEntry.
-    const input = new DataView(bytes.buffer);
+    const input = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
 
     const type = input.getUint16(0);
     const tokenType = Object.values(TOKEN_TYPES).find((t) => t.value === type);

--- a/src/pub_verif_token.ts
+++ b/src/pub_verif_token.ts
@@ -126,7 +126,7 @@ export class TokenRequest {
 
     static deserialize(tokenType: TokenTypeEntry, bytes: Uint8Array): TokenRequest {
         let offset = 0;
-        const input = new DataView(bytes.buffer);
+        const input = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
 
         const type = input.getUint16(offset);
         offset += 2;
@@ -139,7 +139,7 @@ export class TokenRequest {
         offset += 1;
 
         const len = tokenType.Nk;
-        const blindedMsg = new Uint8Array(input.buffer.slice(offset, offset + len));
+        const blindedMsg = bytes.subarray(offset, offset + len);
         offset += len;
 
         return new TokenRequest(tokenKeyId, blindedMsg, tokenType);
@@ -156,7 +156,10 @@ export class TokenRequest {
         new DataView(b).setUint8(0, this.truncatedTokenKeyId);
         output.push(b);
 
-        b = this.blindedMsg.buffer;
+        b = (this.blindedMsg.buffer as ArrayBuffer).slice(
+            this.blindedMsg.byteOffset,
+            this.blindedMsg.byteOffset + this.blindedMsg.byteLength,
+        );
         output.push(b);
 
         return new Uint8Array(joinAll(output));
@@ -184,10 +187,20 @@ export class ExtendedTokenRequest {
         const output = new Array<ArrayBuffer>();
 
         const request = this.request.serialize();
-        output.push(request.buffer);
+        output.push(
+            (request.buffer as ArrayBuffer).slice(
+                request.byteOffset,
+                request.byteOffset + request.byteLength,
+            ),
+        );
 
         const extensions = this.extensions.serialize();
-        output.push(extensions.buffer);
+        output.push(
+            (extensions.buffer as ArrayBuffer).slice(
+                extensions.byteOffset,
+                extensions.byteOffset + extensions.byteLength,
+            ),
+        );
 
         return new Uint8Array(joinAll(output));
     }


### PR DESCRIPTION
## Summary

When using `Uint8Array.subarray()`, the `.buffer` property still points to the original ArrayBuffer, not just the slice. This was causing issues in two places:

1. DataView constructors weren't accounting for byteOffset when parsing subarrays
2. serialize() methods were using `.buffer` directly, which included extra bytes

## Changes

- DataView constructors now use `(bytes.buffer, bytes.byteOffset, bytes.byteLength)`
- serialize() methods now use `buffer.slice(byteOffset, byteOffset + byteLength)` 
- Fixed `tokenEntryToSerializedLength()` which was missing the 3 byte header (token_type + truncated_token_key_id)

## Files changed

- `src/generic_batched_token.ts`
- `src/index.ts`
- `src/priv_verif_token.ts`
- `src/pub_verif_token.ts`

## Testing

- All 144 tests pass in privacypass-ts 
- Verified working with privacypass-issuer (all 35 tests pass using npm pack)