### PR TITLE
use npm trusted publishers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checking out
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - name: Use Node.js 20
-        uses: actions/setup-node@v4
+      - name: Use Node.js 24
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           # registry-url is required to correctly setup authentication per https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages#publishing-packages-to-the-npm-registry
           registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
@@ -32,6 +32,3 @@ jobs:
 
       - name: Publish to npmjs
         run: npm publish
-        env:
-          # To create a new token, go to https://www.npmjs.com/settings/<user>/tokens/, generate a "Granular Access Token" scoped to @cloudflare/privacypass-ts, and update NPM_TOKEN GitHub secret
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
no more NPM_TOKEN that can leak or needs rotation.

we're using https://docs.npmjs.com/trusted-publishers