### PR TITLE
Fix header to token plus test

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,8 +82,6 @@ export async function header_to_token(header: string): Promise<string | null> {
             return null;
     }
 
-    const te = new TextEncoder();
     const authHeader = await fetchToken(client, pt);
-    const encodedToken = base64url.stringify(te.encode(authHeader.toString()));
-    return encodedToken;
+    return authHeader.toString();
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,6 @@
 // Copyright (c) 2023 Cloudflare, Inc.
 // Licensed under the Apache-2.0 license found in the LICENSE file or at https://opensource.org/licenses/Apache-2.0
 
-import { base64url } from 'rfc4648';
 import { WWWAuthenticateHeader } from './auth_scheme/private_token.js';
 import {
     Client as PublicVerifClient,

--- a/test/pub_verif_token.test.ts
+++ b/test/pub_verif_token.test.ts
@@ -8,6 +8,8 @@ import {
     TOKEN_TYPES,
     Token,
     AuthorizationHeader,
+    WWWAuthenticateHeader,
+    header_to_token,
     publicVerif,
     tokenRequestToTokenTypeEntry,
 } from '../src/index.js';
@@ -83,6 +85,63 @@ describe.each(vectors)('PublicVerifiable-Vector-%#', (v: Vectors) => {
         expect(parsedToken.token.authInput.tokenType).toBe(token.authInput.tokenType);
         expect(parsedToken.token.authenticator).toEqual(token.authenticator);
     });
+});
+
+test('header_to_token returns an Authorization header value', async () => {
+    const v = vectors[0];
+    const [{ privateKey, publicKey }, publicKeyEnc] = await keysFromVector(v);
+    const salt = hexToUint8(v.salt);
+    const mode =
+        salt.length == (BlindRSAMode.PSS as number) ? BlindRSAMode.PSS : BlindRSAMode.PSSZero;
+    const nonce = hexToUint8(v.nonce);
+    const blind = hexToUint8(v.blind);
+    const tokChl = TokenChallenge.deserialize(hexToUint8(v.token_challenge));
+    const issuer = new Issuer(mode, tokChl.issuerName, privateKey, publicKey);
+
+    vi.spyOn(crypto, 'getRandomValues')
+        .mockReturnValueOnce(nonce)
+        .mockReturnValueOnce(salt)
+        .mockReturnValueOnce(blind);
+    vi.stubGlobal(
+        'fetch',
+        vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+            const url =
+                input instanceof Request ? input.url : input instanceof URL ? input.href : input;
+            if (url === `https://${tokChl.issuerName}/.well-known/private-token-issuer-directory`) {
+                return new Response(
+                    JSON.stringify({
+                        'issuer-request-uri': `https://${tokChl.issuerName}/issuer`,
+                        'token-keys': [],
+                    }),
+                    { status: 200 },
+                );
+            }
+
+            if (
+                url !== `https://${tokChl.issuerName}/issuer` ||
+                !(init?.body instanceof Uint8Array)
+            ) {
+                return new Response(null, { status: 404 });
+            }
+
+            const tokenRequest = TokenRequest.deserialize(TOKEN_TYPES.BLIND_RSA, init.body);
+            const tokenResponse = await issuer.issue(tokenRequest);
+            return new Response(tokenResponse.serialize(), {
+                status: 200,
+                headers: { 'Content-Type': 'application/private-token-response' },
+            });
+        }),
+    );
+
+    const challengeHeader = new WWWAuthenticateHeader(tokChl, publicKeyEnc).toString();
+    const authHeader = await header_to_token(challengeHeader);
+
+    expect(authHeader).not.toBeNull();
+    if (authHeader === null) {
+        return;
+    }
+    expect(authHeader.startsWith('PrivateToken token=')).toBe(true);
+    expect(AuthorizationHeader.parse(TOKEN_TYPES.BLIND_RSA, authHeader)).toHaveLength(1);
 });
 
 describe('getPublicKeyBytes', () => {


### PR DESCRIPTION
Superseeds #55 

It changes:
1. remove unused rfc4648 import from index.ts
2. adds a regression test
3. rebase onto the latest upstream

fyi @hacklschorsch if you are still around (and apologies for the delay). i've rebased your commit so that you're still credited as a contributor