### PR TITLE
Fix trusted publishers permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write # Required for OIDC token used by npm trusted publishers
 
 jobs:
   release:


### PR DESCRIPTION
`id-token: write` is required, making release of 0.9.0 fail.

Somehow this was not added with previous commits.

Once merged. I'll retag, and re-release 0.9.0. there are no changes to the package, only publication